### PR TITLE
Drop one "o" and rename the project as "Toolbx"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Toolbox website
-===============
+Toolbx website
+==============
 
 To set up jekyll locally on Fedora:
 

--- a/index.md
+++ b/index.md
@@ -2,27 +2,27 @@
 layout: default
 ---
 
-![Toolbox](assets/toolbox.gif){:.full.pixels}
+![Toolbx](assets/toolbox.gif){:.full.pixels}
 
-[Toolbox](https://github.com/containers/toolbox) is a tool for Linux operating systems, which allows the use of containerized command line environments. It is built on top of [Podman](https://podman.io/) and other standard container technologies from [OCI](https://opencontainers.org/).
+[Toolbx](https://github.com/containers/toolbox) is a tool for Linux operating systems, which allows the use of containerized command line environments. It is built on top of [Podman](https://podman.io/) and other standard container technologies from [OCI](https://opencontainers.org/).
 
 This is particularly useful on [OSTree](https://ostree.readthedocs.io/en/latest/) based operating systems like
 [Fedora CoreOS](https://coreos.fedoraproject.org/) and [Silverblue](https://silverblue.fedoraproject.org/). The intention of these systems is to discourage installation of software on the host, and instead install software as (or in) containers — they mostly don't even have package managers like DNF or YUM. This makes it difficult to set up a development environment or install tools for debugging in the usual way.
 
-Toolbox solves this problem by providing a fully mutable container within which one can install their favourite development and debugging tools, editors and SDKs. For example, it's possible to do `yum install ansible` without affecting the base operating system.
+Toolbx solves this problem by providing a fully mutable container within which one can install their favourite development and debugging tools, editors and SDKs. For example, it's possible to do `yum install ansible` without affecting the base operating system.
 
 However, this tool doesn't *require* using an OSTree based system. It works equally well on Fedora Workstation and Server, and that's a useful way to incrementally adopt containerization.
 
-The toolbox environment is based on an [OCI](https://www.opencontainers.org/) image. On Fedora this is the `fedora-toolbox` image. This image is used to create a toolbox container that seamlessly integrates with the rest of the operating system by providing access to the user's home directory, the Wayland and X11 sockets, networking (including Avahi), removable devices (like USB sticks), systemd journal, SSH agent, D-Bus, ulimits, /dev and the udev database, etc..
+The toolbx environment is based on an [OCI](https://www.opencontainers.org/) image. On Fedora this is the `fedora-toolbox` image. This image is used to create a toolbx container that seamlessly integrates with the rest of the operating system by providing access to the user's home directory, the Wayland and X11 sockets, networking (including Avahi), removable devices (like USB sticks), systemd journal, SSH agent, D-Bus, ulimits, /dev and the udev database, etc..
 
 
 ## Installation
 
-Toolbox is installed by default on Fedora Silverblue. On other operating systems it's just a matter of installing the `toolbox` package.
+Toolbx is installed by default on Fedora Silverblue. On other operating systems it's just a matter of installing the `toolbox` package.
 
 ## Usage
 
-### Create your toolbox container:
+### Create your toolbx container:
 ```console
 [user@hostname ~]$ toolbox create
 Created container: fedora-toolbox-33
@@ -31,13 +31,13 @@ Enter with: toolbox enter
 ```
 This will create a container called `fedora-toolbox-<version-id>`.
 
-### Enter the toolbox:
+### Enter the toolbx:
 ```console
 [user@hostname ~]$ toolbox enter
 ⬢[user@toolbox ~]$
 ```
 
-### Remove a toolbox container:
+### Remove a toolbx container:
 ```console
 [user@hostname ~]$ toolbox rm fedora-toolbox-33
 [user@hostname ~]$
@@ -45,7 +45,7 @@ This will create a container called `fedora-toolbox-<version-id>`.
 
 ## Dependencies and Building
 
-Toolbox requires at least Podman 1.4.0 to work, and uses the Meson build system.
+Toolbx requires at least Podman 1.4.0 to work, and uses the Meson build system.
 
 The following dependencies are required to build it:
 
@@ -67,19 +67,19 @@ It can be built and installed as any other typical Meson-based project:
 [user@hostname toolbox]$ sudo ninja -C builddir install
 ```
 
-Toolbox is written in Go. Consult the [src/go.mod](https://github.com/containers/toolbox/blob/main/src/go.mod) file for a full list of all the Go dependencies.
+Toolbx is written in Go. Consult the [src/go.mod](https://github.com/containers/toolbox/blob/main/src/go.mod) file for a full list of all the Go dependencies.
 
-By default, Toolbox uses Go modules and all the required Go packages are automatically downloaded as part of the build. There's no need to worry about the Go dependencies, unless the build environment doesn't have network access or any such peculiarities.
+By default, Toolbx uses Go modules and all the required Go packages are automatically downloaded as part of the build. There's no need to worry about the Go dependencies, unless the build environment doesn't have network access or any such peculiarities.
 
 ## Distro support
 
-By default, Toolbox creates the container using an [OCI](https://www.opencontainers.org/) image called `<ID>-toolbox:<VERSION-ID>`, where `<ID>` and `<VERSION-ID>` are taken from the host's `/usr/lib/os-release`. For example, the default image on a Fedora 33 host would be `fedora-toolbox:33`.
+By default, Toolbx creates the container using an [OCI](https://www.opencontainers.org/) image called `<ID>-toolbox:<VERSION-ID>`, where `<ID>` and `<VERSION-ID>` are taken from the host's `/usr/lib/os-release`. For example, the default image on a Fedora 33 host would be `fedora-toolbox:33`.
 
 This default can be overridden by the `--image` option in `toolbox create`, but operating system distributors should provide an adequately configured default image to ensure a smooth user experience.
 
 ## Image requirements
 
-Toolbox customizes newly created containers in a certain way. This requires certain tools and paths to be present and have certain characteristics inside the OCI image.
+Toolbx customizes newly created containers in a certain way. This requires certain tools and paths to be present and have certain characteristics inside the OCI image.
 
 Tools:
 * `getent(1)`
@@ -106,18 +106,18 @@ Paths:
 * `/etc/resolv.conf`: optional, if present not a bind mount
 * `/etc/timezone`: optional, if present not a bind mount
 
-Toolbox enables `sudo(8)` access inside containers. The following is necessary for that to work:
+Toolbx enables `sudo(8)` access inside containers. The following is necessary for that to work:
 
 * The image should have `sudo(8)` enabled for users belonging to either the   `sudo` or `wheel` groups, and the group itself should exist. File an [issue](https://github.com/containers/toolbox/issues/new) if you really need support for a different group. However, it's preferable to keep this list as short as possible.
 
 * The image should allow empty passwords for `sudo(8)`. This can be achieved by either adding the `nullok` option to the `PAM(8)` configuration, or by add the `NOPASSWD` tag to the `sudoers(5)` configuration.
 
-Since Toolbox only works with OCI images that fulfill certain requirements, it will refuse images that aren't tagged with `com.github.containers.toolbox="true"` and `com.github.debarshiray.toolbox="true"` labels. These labels are meant to be used by the maintainer of the image to indicate that they have read this document and tested that the image works with Toolbox. You can use the following snippet in a Dockerfile for this: 
+Since Toolbx only works with OCI images that fulfill certain requirements, it will refuse images that aren't tagged with `com.github.containers.toolbox="true"` and `com.github.debarshiray.toolbox="true"` labels. These labels are meant to be used by the maintainer of the image to indicate that they have read this document and tested that the image works with Toolbx. You can use the following snippet in a Dockerfile for this: 
 
 ```Dockerfile
 LABEL com.github.containers.toolbox="true"
 ```
 
-The label `com.github.debarshiray.toolbox="true"` was used in previous versions of toolbox but is currently deprecated.
+The label `com.github.debarshiray.toolbox="true"` was used in previous versions of toolbx but is currently deprecated.
 
 [![Zuul](https://zuul-ci.org/gated.svg)](https://softwarefactory-project.io/zuul/t/local/builds?project=containers/toolbox) [![Daily Pipeline](https://softwarefactory-project.io/zuul/api/tenant/local/badge?project=containers/toolbox&pipeline=periodic)](https://softwarefactory-project.io/zuul/t/local/builds?project=containers%2Ftoolbox&pipeline=periodic) [![Arch Linux package](https://img.shields.io/archlinux/v/community/x86_64/toolbox)](https://www.archlinux.org/packages/community/x86_64/toolbox/) [![Fedora package](https://img.shields.io/fedora/v/toolbox/rawhide)](https://src.fedoraproject.org/rpms/toolbox/)


### PR DESCRIPTION
This is meant to make the project more searchable on the Internet. More
and more people have been pointing out that "toolbox" is terribly
difficult to search for, and it's impossible to find any decent
Internet real estate by that name.