### PR TITLE
Link to the full contribution guide

### DIFF
--- a/index.md
+++ b/index.md
@@ -60,4 +60,6 @@ Toolbx is Free Software and is developed in the open. Code can be found on [GitH
   * Contributors are bound to agree to our [Code of Conduct](https://github.com/containers/common/blob/main/CODE-OF-CONDUCT.md).
   * Follow us on [Twitter](https://twitter.com/containertoolbx).
 
+See our [contribution guide](https://github.com/containers/toolbox/blob/main/CONTRIBUTING.md) for further details.
+
 [![Zuul](https://zuul-ci.org/gated.svg)](https://softwarefactory-project.io/zuul/t/local/builds?project=containers/toolbox) [![Daily Pipeline](https://softwarefactory-project.io/zuul/api/tenant/local/badge?project=containers/toolbox&pipeline=periodic)](https://softwarefactory-project.io/zuul/t/local/builds?project=containers%2Ftoolbox&pipeline=periodic) [![Arch Linux package](https://img.shields.io/archlinux/v/community/x86_64/toolbox)](https://www.archlinux.org/packages/community/x86_64/toolbox/) [![Fedora package](https://img.shields.io/fedora/v/toolbox/rawhide)](https://src.fedoraproject.org/rpms/toolbox/)


### PR DESCRIPTION
GitHub pushes projects to have a contribution guide in a file called
CONTRIBUTING.md under their respective code repositories. This is
reflected in the project's Insights -> Community section.

Hence, this guide can't be fully moved to the website.

Instead, to avoid duplicating the content, it's better to link to the
contribution guide from the website.