### PR TITLE
Fix the Custom image section inside the install.md

### DIFF
--- a/install.md
+++ b/install.md
@@ -78,13 +78,19 @@ The following steps can be followed in order to create a custom image:
    sudo: unable to resolve host toolbox: No address associated with hostname
    ```
 
-3. commit the changes:
+3. Exit the toolbox:
+
+   ```console
+   ⬢$ exit
+   ```
+
+4. commit the changes:
 
    ```
    $ podman commit ubuntu-toolbox-22.04 my-custom-image
    ```
 
-4. You can now create new custom toolboxes by doing:
+5. You can now create new custom toolboxes by doing:
 
    ```
    $ toolbox create -i my-custom-image

--- a/install.md
+++ b/install.md
@@ -74,8 +74,16 @@ The following steps can be followed in order to create a custom image:
 
    ```console
    $ toolbox enter ubuntu-toolbox-22.04
-   ⬢$ sudo apt install -y neofetch
-   sudo: unable to resolve host toolbox: No address associated with hostname
+   ⬢$ sudo apt update && sudo apt --yes install neofetch
+   Get:1 http://security.ubuntu.com/ubuntu jammy-security InRelease [110 kB]
+   Get:2 http://archive.ubuntu.com/ubuntu jammy InRelease [270 kB]
+   Get:3 http://security.ubuntu.com/ubuntu jammy-security/main amd64 Packages [802 kB]
+   Get:4 http://security.ubuntu.com/ubuntu jammy-security/main Translation-en [169 kB]
+   Get:5 http://security.ubuntu.com/ubuntu jammy-security/main amd64 c-n-f Metadata [11.3 kB]
+   Get:6 http://security.ubuntu.com/ubuntu jammy-security/restricted amd64 Packages [884 kB]
+   …
+   …
+   …
    ```
 
 3. Exit the toolbox:

--- a/install.md
+++ b/install.md
@@ -62,30 +62,30 @@ There are two different ways of creating a custom image. The first one consists 
 
 The following steps can be followed in order to create a custom image:
 
-    1. Create a toolbox - in this case I'm using a custom image as base
+1. Create a toolbox - in this case I'm using a custom image as base
 
-        ```
-        $ toolbox create -i quay.io/toolbx/ubuntu-toolbox:22.04
-        Created container: ubuntu-toolbox-22.04
-        Enter with: toolbox enter ubuntu-toolbox-22.04
-        ```
+   ```
+   $ toolbox create -i quay.io/toolbx/ubuntu-toolbox:22.04
+   Created container: ubuntu-toolbox-22.04
+   Enter with: toolbox enter ubuntu-toolbox-22.04
+   ```
 
-    2. Enter the toolbox and do modifications
+2. Enter the toolbox and do modifications
 
-        ```
-        $ toolbox enter ubuntu-toolbox-22.04
-        ⬢$ sudo apt install -y neofetch
-        sudo: unable to resolve host toolbox: No address associated with hostname
-        ```
+   ```
+   $ toolbox enter ubuntu-toolbox-22.04
+   ⬢$ sudo apt install -y neofetch
+   sudo: unable to resolve host toolbox: No address associated with hostname
+   ```
 
-    3. commit the changes:
+3. commit the changes:
 
-        ```
-        $ podman commit ubuntu-toolbox-22.04 my-custom-image
-        ```
+   ```
+   $ podman commit ubuntu-toolbox-22.04 my-custom-image
+   ```
 
-    4. You can now create new custom toolboxes by doing: 
+4. You can now create new custom toolboxes by doing:
 
-        ```
-        $ toolbox create -i my-custom-image
-        ```
+   ```
+   $ toolbox create -i my-custom-image
+   ```

--- a/install.md
+++ b/install.md
@@ -64,7 +64,7 @@ The following steps can be followed in order to create a custom image:
 
 1. Create a toolbox - in this case I'm using a custom image as base
 
-   ```
+   ```console
    $ toolbox create -i quay.io/toolbx/ubuntu-toolbox:22.04
    Created container: ubuntu-toolbox-22.04
    Enter with: toolbox enter ubuntu-toolbox-22.04
@@ -72,7 +72,7 @@ The following steps can be followed in order to create a custom image:
 
 2. Enter the toolbox and do modifications
 
-   ```
+   ```console
    $ toolbox enter ubuntu-toolbox-22.04
    ⬢$ sudo apt install -y neofetch
    sudo: unable to resolve host toolbox: No address associated with hostname
@@ -86,12 +86,12 @@ The following steps can be followed in order to create a custom image:
 
 4. commit the changes:
 
-   ```
+   ```console
    $ podman commit ubuntu-toolbox-22.04 my-custom-image
    ```
 
 5. You can now create new custom toolboxes by doing:
 
-   ```
+   ```console
    $ toolbox create -i my-custom-image
    ```


### PR DESCRIPTION
The Custom Image had *```* showing instead of block of codes, the apt-get install output was also slightly weird.