### PR TITLE
Fix dead OSTree hyperlink on index

### DIFF
--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ layout: default
 
 Toolbox environments have seamless access to the user's home directory, the Wayland and X11 sockets, networking (including Avahi), removable devices (like USB sticks), systemd journal, SSH agent, D-Bus, ulimits, /dev and the udev database, etc..
 
-This is particularly useful on [OSTree](https://ostree.readthedocs.io/en/latest/) based operating systems like
+This is particularly useful on [OSTree](https://ostreedev.github.io/ostree/) based operating systems like
 [Fedora CoreOS](https://fedoraproject.org/coreos/) and [Silverblue](https://fedoraproject.org/silverblue/). The intention of these systems is to discourage installation of software on the host, and instead install software as (or in) containers — they mostly don't even have package managers like DNF or YUM. This makes it difficult to set up a development environment or troubleshoot the operating system in the usual way.
 
 Toolbx solves this problem by providing a fully mutable container within which one can install their favourite development and troubleshooting tools, editors and SDKs. For example, it's possible to do `yum install ansible` without affecting the base operating system.


### PR DESCRIPTION
As of 2020, OSTree's documentation is hosted via GitHub pages; a hyperlink found on the index links to OSTree's old documentation (hosted on readthedocs.io), which is now dead. This PR rectifies the issue.

Thanks & happy 2024